### PR TITLE
Don't include system timestamps in generated fixtures

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -84,9 +84,9 @@ FixtureBuilder.configure do |fbuilder|
 
   # now declare objects
   fbuilder.factory do
-    david = Factory(:user, :unique_name => "david")
-    ipod = Factory(:product, :name => "iPod")
-    Factory(:purchase, :user => david, :product => ipod)
+    david = Factory(:user, unique_name: "david")
+    ipod = Factory(:product, name: "iPod")
+    Factory(:purchase, user: david, product: ipod)
   end
 end
 ```    
@@ -118,8 +118,8 @@ You can also hint at a name or manually name an object.  Both of the following l
 work to rename `purchase_001` to `davids_ipod`:
 
 ```ruby
-fbuilder.name(:davids_ipod, Factory(:purchase, :user => david, :product => ipod))
-@davids_ipod = Factory(:purchase, :user => david, :product => ipod)
+fbuilder.name(:davids_ipod, Factory(:purchase, user: david, product: ipod))
+@davids_ipod = Factory(:purchase, user: david, product: ipod)
 ```
 
 Another way to name fixtures is to use the name_model_with. To use it you create a block that

--- a/test/fixture_builder_test.rb
+++ b/test/fixture_builder_test.rb
@@ -115,4 +115,19 @@ class FixtureBuilderTest < Test::Unit::TestCase
       assert_equal first_modified_time, second_modified_time
     end
   end
+
+  def test_setting_created_at
+    create_and_blow_away_old_db
+    force_fixture_generation
+
+    FixtureBuilder.configure do |fbuilder|
+      fbuilder.files_to_check += Dir[test_path("*.rb")]
+      fbuilder.factory do
+        @mimic = MagicalCreature.create(:name => 'trix', :species => 'mimic')
+      end
+    end
+    generated_fixture = YAML.load(File.open(test_path("fixtures/magical_creatures.yml")))
+    assert_equal 'mimic', generated_fixture.keys.first
+    # todo: test something specific about the timestamps
+  end
 end

--- a/test/legacy_fixture_mode_fixture_generation_test.rb
+++ b/test/legacy_fixture_mode_fixture_generation_test.rb
@@ -9,8 +9,8 @@ class LegacyFixtureModeFixtureGenerationTest < Test::Unit::TestCase
     FixtureBuilder.configure do |fbuilder|
       fbuilder.legacy_fixtures = Dir[test_path("legacy_fixtures/*.yml"), test_path("other_legacy_fixture_set/*.yml")] 
       fbuilder.factory do
-        MagicalCreature.create(:name => "frank", :species => "unicorn")
-        MagicalCreature.create(:name => "loch ness monster", :species => "sea creature", :deleted => true)
+        MagicalCreature.create(name: "frank", species: "unicorn")
+        MagicalCreature.create(name: "loch ness monster", species: "sea creature", deleted: true)
       end
     end
 

--- a/test/legacy_fixture_mode_test.rb
+++ b/test/legacy_fixture_mode_test.rb
@@ -23,7 +23,7 @@ class LegacyFixtureModeTest < Test::Unit::TestCase
     FixtureBuilder.configure do |fbuilder|
       fbuilder.files_to_check += Dir[test_path("*.rb")]
       fbuilder.factory do
-        MagicalCreature.create :name => "Melinda", :species => "Philanthropist"
+        MagicalCreature.create(name: "Melinda", species: "Philanthropist")
       end
     end
     assert_equal 1, MagicalCreature.all.size
@@ -33,7 +33,7 @@ class LegacyFixtureModeTest < Test::Unit::TestCase
     FixtureBuilder.configure do |fbuilder|
       fbuilder.legacy_fixtures = Dir[test_path("legacy_fixtures/*.yml"), test_path("other_legacy_fixture_set/*.yml")] 
       fbuilder.factory do
-        MagicalCreature.create :name => "Barry", :species => "Party Guy"
+        MagicalCreature.create(name: "Barry", species: "Party Guy")
       end
     end
     assert_equal 4, MagicalCreature.all.size

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,6 +54,8 @@ def create_and_blow_away_old_db
     t.column :species, :string
     t.column :powers, :string
     t.column :deleted, :boolean, :default => false, :null => false
+    t.column :created_at, :datetime
+    t.column :updated_at, :datetime
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,11 +32,11 @@ class MagicalCreature < ActiveRecord::Base
   serialize :powers, Array
 
   if ActiveRecord::VERSION::MAJOR >= 4
-    default_scope -> { where(:deleted => false) }
+    default_scope -> { where(deleted: false) }
 
     attribute :virtual, ActiveRecord::Type::Integer.new
   else
-    default_scope :conditions => { :deleted => false }
+    default_scope :conditions => { deleted: false }
   end
 end
 
@@ -49,11 +49,11 @@ def create_and_blow_away_old_db
   }
   ActiveRecord::Base.establish_connection(:test)
 
-  ActiveRecord::Base.connection.create_table(:magical_creatures, :force => true) do |t|
+  ActiveRecord::Base.connection.create_table(:magical_creatures, force: true) do |t|
     t.column :name, :string
     t.column :species, :string
     t.column :powers, :string
-    t.column :deleted, :boolean, :default => false, :null => false
+    t.column :deleted, :boolean, default: false, null: false
     t.column :created_at, :datetime
     t.column :updated_at, :datetime
   end


### PR DESCRIPTION
Part of the reason we forked this gem in the first place was so that we could make this change: we don't want the `created_at` and `updated_at` timestamps to get re-generated every time we run the fixture builder command. (Especially as we add more factories that are set up with fixture builder, it will start to clog PRs up badly that every single fixture created this way would have a diff for the timestamps every time.)

So here, we are not setting `updated_at`, and we're only setting `created_at` if there's a specific date in the past or future that it's being set to in the factory (as there are certain fixtures that use a particular `created_at` date to test specific things.)

I also went through and updated some of the old hashrocket syntax that was bothering me, lol 