### PR TITLE
Add support for generated ids

### DIFF
--- a/lib/fixture_builder/configuration.rb
+++ b/lib/fixture_builder/configuration.rb
@@ -17,7 +17,7 @@ module FixtureBuilder
 
     ACCESSIBLE_ATTRIBUTES = [:select_sql, :delete_sql, :skip_tables, :files_to_check, :record_name_fields,
                              :fixture_builder_file, :fixture_directory, :after_build, :legacy_fixtures, :model_name_procs,
-                             :write_empty_files, :order_by_created_at]
+                             :write_empty_files, :generate_ids, :generate_ids_excluded_column_names]
     attr_accessor(*ACCESSIBLE_ATTRIBUTES)
 
     SCHEMA_FILES = ['db/schema.rb', 'db/development_structure.sql', 'db/test_structure.sql', 'db/production_structure.sql']
@@ -27,7 +27,8 @@ module FixtureBuilder
       @use_sha1_digests = opts[:use_sha1_digests] || false
       @file_hashes = file_hashes
       @write_empty_files = true
-      @order_by_created_at = false
+      @generate_ids = false
+      @generate_ids_excluded_column_names = []
     end
 
     def include(*args)

--- a/lib/fixture_builder/delegations.rb
+++ b/lib/fixture_builder/delegations.rb
@@ -13,7 +13,7 @@ module FixtureBuilder
 
     module Namer
       def self.included(base)
-        base.delegate :record_name, :populate_custom_names, :name, :name_model_with, :to => :@namer
+        base.delegate :record_name, :populate_custom_names, :name, :name_model_with, :name_and_save, :to => :@namer
       end
     end
   end

--- a/lib/fixture_builder/namer.rb
+++ b/lib/fixture_builder/namer.rb
@@ -1,10 +1,14 @@
 module FixtureBuilder
   class Namer
+    include ActiveRecord::TestFixtures
     include Delegations::Configuration
+
+    attr_reader :custom_name_ids
 
     def initialize(configuration)
       @configuration = configuration
       @custom_names = {}
+      @custom_name_ids = {}
       @model_name_procs = {}
       @record_names = {}
     end
@@ -20,8 +24,18 @@ module FixtureBuilder
         key = [model_object.class.table_name, model_object.id]
         raise "Cannot set name for #{key.inspect} object twice" if @custom_names[key]
         @custom_names[key] = custom_name
+        @custom_name_ids[model_object.id] = custom_name
         model_object
       end
+    end
+
+    def name_and_save(custom_name, model_object)
+      model_object.id = ActiveRecord::FixtureSet.identify(custom_name)
+      model_object.save
+
+      name(custom_name, model_object)
+
+      model_object
     end
 
     def populate_custom_names(created_fixtures)


### PR DESCRIPTION
Fixtures provide stable auto-generated ids (see https://api.rubyonrails.org/v3.1/classes/ActiveRecord/Fixtures.html) where
> The generated ID for a given label is constant, so we can discover any fixture’s ID without loading anything, as long as we know the label

This PR introduces a new configuration option to `generate_ids` utilizing `ActiveRecord::FixtureSet.identify`, which takes a fixture label and provides an `id`

This allows us to provide a human-readable label for associations (for easy parsing when reviewing generated fixture `.yml` files)