### PR TITLE
Support nil with generated ids

### DIFF
--- a/lib/fixture_builder/builder.rb
+++ b/lib/fixture_builder/builder.rb
@@ -190,7 +190,7 @@ module FixtureBuilder
       record.select { |k, v| k.match(/_id$/)}.each_pair do |key, value|
         id_to_lookup = record[key]
 
-        next if @namer.custom_name_ids[id_to_lookup].nil?
+        next if id_to_lookup && @namer.custom_name_ids[id_to_lookup].nil?
         next if @configuration.generate_ids_excluded_column_names.include?(key)
 
         key_prefix = key.delete_suffix("_id")


### PR DESCRIPTION
This ensures that even when a reference has a `nil` value, we still provide the label for a generated id as opposed to the database id, e.g., 

`vehicle: ` instead of `vehicle_id: `

for consistency within fixture `.yml` files